### PR TITLE
Allow authenticate right after Smart-ID registration

### DIFF
--- a/lib/smart_id/utils/certificate_validator.rb
+++ b/lib/smart_id/utils/certificate_validator.rb
@@ -23,8 +23,8 @@ module SmartId::Utils
       # cert_store.add_dir(File.dirname(__FILE__)+"/../../../trusted_certs/")
       # cert_store.purpose = OpenSSL::X509::PURPOSE_ANY
       # OpenSSL::X509::Store.new.verify(@certificate) &&
-      @certificate.not_before.to_date < Date.today &&
-        @certificate.not_after.to_date > Date.today
+      @certificate.not_before.to_date <= Date.today &&
+        @certificate.not_after.to_date >= Date.today
     end
 
     def validate_certificate!


### PR DESCRIPTION
Fix InvalidResponseCertificate error on Smart-ID use right after Smart-ID registration. Specification states that not_before/not_after are inclusive. In reality these values contain time